### PR TITLE
Fix bug where no paused requests would throw an exception

### DIFF
--- a/intermission_helpers.lua
+++ b/intermission_helpers.lua
@@ -55,13 +55,9 @@ elseif ngx.var.uri == '/_intermission/disable' then
   pausedreqs:delete(enabled_key)
 
   -- Say how many connections we paused after we let them all go.
-  local id = pausedreqs:get(id_key)
+  local paused_count = tonumber(pausedreqs:get(id_key)) or 0
 
-  if id == nil then
-    id = 0
-  end
-
-  ngx.log(ngx.ERR, 'Pause disabled. ' .. id .. ' requests were held in-flight.')
+  ngx.log(ngx.ERR, 'Pause disabled. ' .. paused_count .. ' requests were held in-flight.')
 
   ngx.say("Pause disabled.")
   ngx.exit(200)


### PR DESCRIPTION
We have to ensure id isn’t nil, so after we interrogate
`pausedreqs:get(id_key)`, we check that our result (`id`) is not nil.
If it is, set the result (`id`) to 0, and continue.
